### PR TITLE
Commenting out all child streams as it is not required now.

### DIFF
--- a/tap_monday/tap.py
+++ b/tap_monday/tap.py
@@ -15,11 +15,11 @@ from tap_monday.streams import (
 )
 
 STREAM_TYPES = [
-    WorkspacesStream,
+    # WorkspacesStream,
     BoardsStream,
-    BoardViewsStream,
-    ColumnsStream,
-    GroupsStream,
+    # BoardViewsStream,
+    # ColumnsStream,
+    # GroupsStream,
 ]
 
 


### PR DESCRIPTION
Commenting out all child streams as it is not required now. This can be added later on request